### PR TITLE
Fixed bug

### DIFF
--- a/discussion.py
+++ b/discussion.py
@@ -51,7 +51,7 @@ def build_parse_tree(fp_exp):
             current_tree.set_root_val(int(i))
             parent = p_stack.pop()
             current_tree = parent
-        elif i in ['+', '-', '*', '/', ')']:
+        elif i in ['+', '-', '*', '/']:
             current_tree.set_root_val(i)
             current_tree.insert_right('')
             p_stack.add(current_tree)


### PR DESCRIPTION
Fixed the bug that was preventing the build_parse_tree() to function correctly. 
The ')' didn't need to be in the list of characters to check for when setting the root value of the current tree.